### PR TITLE
Fixing #10

### DIFF
--- a/resolvers/clients/overall-stats.js
+++ b/resolvers/clients/overall-stats.js
@@ -11,7 +11,7 @@ class OverallStatsClient {
       // The whole idea is to allow creating the data only once for each day.
       const now = new Date();
       const day = fixCharLengthToTwo(now.getDate());
-      const month = fixCharLengthToTwo(now.getMonth());
+      const month = fixCharLengthToTwo(now.getMonth() + 1);
       let createdOn = `${day}.${month}.${now.getFullYear()}`;
       this.getTodaysOverall(createdOn).then(result => {
         if (result.length > 0) {


### PR DESCRIPTION
`now.getMonth()` returns back zero-indexed months.

```
January = 0
February = 1
...
```