### PR TITLE
[fix] use no-cache fetch policy for query

### DIFF
--- a/packages/stats-pages/src/components/TopEpisodesChart.js
+++ b/packages/stats-pages/src/components/TopEpisodesChart.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component } from 'react';
 import {
   LineChart,
   Line,
@@ -31,61 +31,61 @@ const QUERY_EPISODES_STATS = title => gql`
   }
 `;
 
-const TopEpisodesChart = ({ videos, episode }) => {
-  if (!episode) {
-    return <p>Devam etmek için bir seçim yapmanız gerekiyor.</p>;
-  }
+class TopEpisodesChart extends Component {
+  render() {
+    const { videos, episode } = this.props;
 
-  const youtubeVideos = videos.filter(video => {
-    const episodeTitle = episode.title;
-    return compareTwoStrings(video.snippet.title, episodeTitle) * 100 > 60;
-  });
+    const youtubeVideos = videos.filter(video => {
+      const episodeTitle = episode.title;
+      return compareTwoStrings(video.snippet.title, episodeTitle) * 100 > 60;
+    });
 
-  return (
-    <Query query={QUERY_EPISODES_STATS(episode.title)}>
-      {result => {
-        if (!result.data || !result.data.podcasts) {
-          return <Loading />;
-        }
+    return (
+      <Query query={QUERY_EPISODES_STATS(episode.title)} fetchPolicy="no-cache">
+        {({ data }) => {
+          if (!data || !data.podcasts) {
+            return <Loading />;
+          }
 
-        const data = result.data.podcasts[0].episodes[0].downloads.by_interval;
-        const youtubeVideoCount = youtubeVideos.length
-          ? youtubeVideos[0].statistics.viewCount
-          : '-';
+          const chartData = data.podcasts[0].episodes[0].downloads.by_interval;
+          const youtubeVideoCount = youtubeVideos.length
+            ? youtubeVideos[0].statistics.viewCount
+            : '-';
 
-        return (
-          <div className="dashboard--items-container">
-            <div className="value">
-              <OverallValue
-                text="Youtube İzlenme Sayısı"
-                value={youtubeVideoCount}
-              />
-            </div>
-            <div className="value">
-              <OverallValue
-                text="Podcast Dinlenme Sayısı"
-                value={episode.downloads.total}
-              />
-            </div>
-            <ResponsiveContainer height={170}>
-              <LineChart data={data}>
-                <CartesianGrid strokeDasharray="1 1" />
-                <XAxis dataKey="interval" hide />
-                <Tooltip />
-                <Line
-                  type="basis"
-                  dataKey="downloads_total"
-                  stroke="#8884d8"
-                  dot={false}
-                  activeDot={{ r: 5 }}
+          return (
+            <div className="dashboard--items-container">
+              <div className="value">
+                <OverallValue
+                  text="Youtube İzlenme Sayısı"
+                  value={youtubeVideoCount}
                 />
-              </LineChart>
-            </ResponsiveContainer>
-          </div>
-        );
-      }}
-    </Query>
-  );
-};
+              </div>
+              <div className="value">
+                <OverallValue
+                  text="Podcast Dinlenme Sayısı"
+                  value={episode.downloads.total}
+                />
+              </div>
+              <ResponsiveContainer height={170}>
+                <LineChart data={chartData}>
+                  <CartesianGrid strokeDasharray="1 1" />
+                  <XAxis dataKey="interval" hide />
+                  <Tooltip />
+                  <Line
+                    type="basis"
+                    dataKey="downloads_total"
+                    stroke="#8884d8"
+                    dot={false}
+                    activeDot={{ r: 5 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+          );
+        }}
+      </Query>
+    );
+  }
+}
 
 export default TopEpisodesChart;

--- a/packages/stats-pages/src/components/tabs/TotalListensTabView.js
+++ b/packages/stats-pages/src/components/tabs/TotalListensTabView.js
@@ -4,9 +4,9 @@ import TopEpisodesChart from '../TopEpisodesChart';
 import Card from '../ui/Card';
 
 export class TotalListensTabView extends Component {
-  constructor() {
-    super();
-    this.state = { options: [], selectedItem: null };
+  constructor(props) {
+    super(props);
+    this.state = { options: [], selectedItem: '' };
   }
 
   componentDidMount = () => {
@@ -47,7 +47,11 @@ export class TotalListensTabView extends Component {
             })
           }
         />
-        <TopEpisodesChart episode={selectedItem} videos={youtubeVideos} />
+        {selectedItem ? (
+          <TopEpisodesChart episode={selectedItem} videos={youtubeVideos} />
+        ) : (
+          <p>Devam etmek için bir seçim yapmanız gerekiyor.</p>
+        )}
       </Card>
     );
   }


### PR DESCRIPTION
This PR is fixing #44.

Query's fetch policy was "cache-first" by default. Our TopEpisodesChart was re-rendering after change select field value but Query wasn't fetch again because of fetch policy.

So, now I'm using "no-cache" fetch policy instead of cache-first. It is works.